### PR TITLE
docs(badges): fix build badges after action renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat)](https://github.com/prettier/prettier)
 [![style: styled-components](https://img.shields.io/badge/style-%F0%9F%92%85%20styled--components-orange.svg?colorB=daa357&colorA=db748e)](https://github.com/styled-components/styled-components)
 [![Lint](https://github.com/tillhainbach/gatsby-clean-starter/actions/workflows/lint.yaml/badge.svg)](https://github.com/tillhainbach/gatsby-clean-starter/actions/workflows/lint.yaml)
-[![Gatsby Publish Build Validation](https://github.com/tillhainbach/gatsby-clean-starter/actions/workflows/build-validation.yaml/badge.svg)](https://github.com/tillhainbach/gatsby-clean-starter/actions/workflows/build-validation.yaml)
+[![Gatsby Publish Build Validation](https://github.com/tillhainbach/gatsby-clean-starter/actions/workflows/build.yaml/badge.svg)](https://github.com/tillhainbach/gatsby-clean-starter/actions/workflows/build-validation.yaml)
 [![Lint Commit Messages](https://github.com/tillhainbach/gatsby-clean-starter/actions/workflows/commitlint.yml/badge.svg)](https://github.com/tillhainbach/gatsby-clean-starter/actions/workflows/commitlint.yml)
-
 
 This starter is based on Fabian Schultz's [Gatsby Universal](https://github.com/fabe/gatsby-universal) a greate, clean starter theme, but unfortunately outdated.
 


### PR DESCRIPTION
fix broken github action badge after renaming action to build.yaml from build-validation.yaml